### PR TITLE
Added debugging with --debug and --inspect

### DIFF
--- a/lib/ewd-qoper8.js
+++ b/lib/ewd-qoper8.js
@@ -49,8 +49,33 @@ var qoper8 = function() {
     loaderFilePath: 'node_modules/ewd-qoper8-worker.js',
     loaderText: loaderFile,
     process: {},
-    list: []
+    list: [],
+		debugPort: 0,
+		inspectPort: 0
   };
+	// begin change for --inspect & --debug debugging (in addition to added debugPort & inspectPort above in this.worker)
+	var me = this;
+	process.execArgv.forEach(function (option, index) {
+    if (option.indexOf('--inspect') !== -1) {
+			var pieces = option.split('=');
+			if (pieces[1]) {
+				me.worker.inspectPort = parseInt(pieces[1]);
+			}
+			else {
+				me.worker.inspectPort = 9229;
+			}
+		}
+    if (option.indexOf('--debug') !== -1) {
+			var pieces = option.split('=');
+			if (pieces[1]) {
+				me.worker.debugPort = parseInt(pieces[1]);
+			}
+			else {
+				me.worker.debugPort = 5858;
+			}
+		}
+	});	
+	// end change for --inspect & --debug debugging
   this.master = {};
   this.queue = [];
   this.responseHandler = {};

--- a/lib/master/proto/startWorker.js
+++ b/lib/master/proto/startWorker.js
@@ -41,7 +41,23 @@ function startWorker(customQueue) {
     this.worker.module
   ];
 
-  var workerProcess = cp.fork(this.worker.loaderFilePath, args, {env: process.env});
+	// begin change for --inspect debugging
+	var me = this;
+	var execArgv = process.execArgv.map(function (option, index) {
+    if (option.indexOf('--inspect') !== -1) {
+			me.worker.inspectPort = me.worker.inspectPort + 1;
+			return '--inspect=' + me.worker.inspectPort;
+		}
+    else if ((option.indexOf('--debug') !== -1) && (option.indexOf('--debug-brk') === -1)) {
+			me.worker.debugPort = me.worker.debugPort + 1;
+			return '--debug=' + me.worker.debugPort;
+		}
+		else {
+			return option;
+		}
+	});
+  var workerProcess = cp.fork(this.worker.loaderFilePath, args, { execArgv: execArgv, env: process.env });
+	// end change for --inspect debugging
   var q = this;
 
   workerProcess.on('message', function(responseObj) {


### PR DESCRIPTION
this addition allow to debug with th estandard Node.js debugging functionality.

It will not work with --debug-brk option because Node.js child.send() method doesn't buffer messages if the --debug-brk option is active.